### PR TITLE
Implement admin CRUD UI and API

### DIFF
--- a/my-portfolio/src/AdminDashboard.jsx
+++ b/my-portfolio/src/AdminDashboard.jsx
@@ -1,10 +1,28 @@
 // src/pages/AdminDashboard.jsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function AdminDashboard() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [message, setMessage] = useState('');
+  const [posts, setPosts] = useState([]);
+  const [editing, setEditing] = useState(null); // {slug, title, content}
+
+  const token = localStorage.getItem('authToken');
+
+  const fetchPosts = async () => {
+    const res = await fetch('/api/admin/posts', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPosts(data.posts || []);
+    }
+  };
+
+  useEffect(() => {
+    fetchPosts();
+  }, []);
 
   const handleNewPost = async (e) => {
     e.preventDefault();
@@ -26,32 +44,123 @@ export default function AdminDashboard() {
     if (response.ok) {
       setTitle('');
       setContent('');
+      fetchPosts();
+    }
+  };
+
+  const startEdit = async (slug) => {
+    const res = await fetch(`/api/admin/posts?slug=${slug}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setEditing({ slug, title: slug, content: data.content });
+    }
+  };
+
+  const handleUpdate = async (e) => {
+    e.preventDefault();
+    if (!editing) return;
+    setMessage('Updating...');
+    const res = await fetch('/api/admin/posts', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(editing),
+    });
+    const data = await res.json();
+    setMessage(data.message);
+    if (res.ok) {
+      setEditing(null);
+      fetchPosts();
+    }
+  };
+
+  const handleDelete = async (slug) => {
+    if (!confirm('Delete this post?')) return;
+    const res = await fetch(`/api/admin/posts?slug=${slug}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    setMessage(data.message);
+    if (res.ok) {
+      fetchPosts();
     }
   };
 
   return (
-    <div>
-      <h2>Admin Dashboard</h2>
-      <form onSubmit={handleNewPost}>
-        <h3>Create New Post</h3>
+    <div className="space-y-8">
+      <h2 className="text-2xl font-bold">Admin Dashboard</h2>
+
+      <form onSubmit={handleNewPost} className="space-y-4 bg-accent p-4 rounded shadow">
+        <h3 className="text-xl font-semibold">Create New Post</h3>
         <input
           type="text"
           placeholder="Post Title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           required
+          className="w-full p-2 border border-contrast rounded"
         />
-        <br />
         <textarea
           placeholder="Write your post content here (MDX)..."
           value={content}
           onChange={(e) => setContent(e.target.value)}
-          rows={15}
+          rows={8}
           required
+          className="w-full p-2 border border-contrast rounded"
         ></textarea>
-        <br />
-        <button type="submit">Create Post</button>
+        <button className="px-4 py-2 bg-secondary text-white rounded hover:bg-darkback" type="submit">
+          Create Post
+        </button>
       </form>
+
+      {editing && (
+        <form onSubmit={handleUpdate} className="space-y-4 bg-accent p-4 rounded shadow">
+          <h3 className="text-xl font-semibold">Edit {editing.slug}</h3>
+          <input
+            type="text"
+            value={editing.title}
+            onChange={(e) => setEditing({ ...editing, title: e.target.value })}
+            required
+            className="w-full p-2 border border-contrast rounded"
+          />
+          <textarea
+            value={editing.content}
+            onChange={(e) => setEditing({ ...editing, content: e.target.value })}
+            rows={8}
+            required
+            className="w-full p-2 border border-contrast rounded"
+          ></textarea>
+          <button className="px-4 py-2 bg-secondary text-white rounded hover:bg-darkback" type="submit">
+            Update Post
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(null)}
+            className="ml-2 px-4 py-2 border border-contrast rounded"
+          >
+            Cancel
+          </button>
+        </form>
+      )}
+
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold">Existing Posts</h3>
+        {posts.map((p) => (
+          <div key={p.slug} className="flex justify-between items-center bg-contrast text-white p-2 rounded">
+            <span>{p.title}</span>
+            <div className="space-x-2">
+              <button onClick={() => startEdit(p.slug)} className="px-2 py-1 bg-secondary text-white rounded">Edit</button>
+              <button onClick={() => handleDelete(p.slug)} className="px-2 py-1 bg-red-600 text-white rounded">Delete</button>
+            </div>
+          </div>
+        ))}
+      </div>
+
       {message && <p>{message}</p>}
     </div>
   );

--- a/my-portfolio/src/AdminLogin.jsx
+++ b/my-portfolio/src/AdminLogin.jsx
@@ -1,7 +1,7 @@
 // src/AdminLogin.jsx
 
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom'; // 1. Import useNavigate
+import { useNavigate } from 'react-router-dom';
 
 export default function AdminLogin() {
   const [password, setPassword] = useState('');
@@ -41,22 +41,26 @@ export default function AdminLogin() {
   };
 
   return (
-    <div style={{ maxWidth: '400px', margin: '5rem auto', padding: '2rem', border: '1px solid #ddd', borderRadius: '8px' }}>
-      <h2>Admin Login</h2>
-      <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: '1rem' }}>
-          <label htmlFor="password">Password</label>
+    <div className="max-w-md mx-auto mt-20 p-6 bg-accent text-text rounded-lg shadow">
+      <h2 className="text-2xl font-bold mb-4 text-center">Admin Login</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="flex flex-col">
+          <label htmlFor="password" className="mb-1 font-semibold">Password</label>
           <input
             type="password"
             id="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
-            style={{ width: '100%', padding: '8px', marginTop: '4px' }}
+            className="p-2 border border-contrast rounded"
           />
         </div>
-        {error && <p style={{ color: 'red' }}>{error}</p>}
-        <button type="submit" disabled={isLoading} style={{ width: '100%', padding: '10px' }}>
+        {error && <p className="text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full py-2 bg-secondary text-white rounded hover:bg-darkback transition"
+        >
           {isLoading ? 'Logging in...' : 'Login'}
         </button>
       </form>


### PR DESCRIPTION
## Summary
- restyle AdminLogin to use Tailwind
- extend AdminDashboard to list, edit and delete posts
- add CRUD routes to `api/admin/posts.js`

## Testing
- `npm run lint` *(fails: 38 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688c184ea90c8320ac0196d87d97bb3c